### PR TITLE
Don't try to call s.indexOf unless we know s is a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ if (!version.match(/^0\.10/)) {
 
   var superConsoleError = console.error;
   console.error = function(s) {
-    if (s.indexOf("js-bson: Failed to load c++ bson extension, using pure JS version") !== -1) {
+    if (typeof s == "string" && s.indexOf("js-bson: Failed to load c++ bson extension, using pure JS version") !== -1) {
       return;
     }
     return superConsoleError.apply(console, arguments);


### PR DESCRIPTION
We had an issue where we were calling console.error() with an object, and line 26 here was causing node to totally throw up with an uncaught exception error. Calling console.error with an object is perfectly legitimate (https://developer.mozilla.org/en-US/docs/Web/API/Console/error), and oh-ten-bc shouldn't get in the way of that.
